### PR TITLE
chore: Enable insecure auth from any user/pass

### DIFF
--- a/ecs.tf
+++ b/ecs.tf
@@ -41,9 +41,9 @@ resource "aws_ecs_task_definition" "mailhog" {
         }
     },
     "environment": [
-        {"name": "MH_HOSTNAME", "value": "${var.hostname}"},
-        {"name": "MH_STORAGE", "value": "memory"},
-        {"name": "MP_TAGS_USERNAME", "value": "true"}
+        {"name": "MP_TAGS_USERNAME", "value": "true"},
+        {"name": "MP_SMTP_AUTH_ACCEPT_ANY", "value": "true"},
+        {"name": "MP_SMTP_AUTH_ALLOW_INSECURE", "value": "true"}
     ]
 }]
 DEFINITION


### PR DESCRIPTION
We've historically sent anonymous emails with no SMTP user/password, which is accepted by this fake mail server.

However, to get the username auto-tagging to work, we need to enable the insecure "auth" options so the username we want to use as a tag can be "authenticated". This is not any more insecure than the existing configuration, which allows unauthenticated "email"[^NOT-REAL].

[^NOT-REAL]: It's not a real email server, so who cares.

I have removed the two `MH_` env vars; these were holdovers from the MailHog era and no longer do anything.